### PR TITLE
Add Scanf and support for N and Z

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 Implementation of `sprintf` and `sscanf` for Coq
 
+## Example
+
+```Coq
+Require Import Coq.Strings.String.
+Require Import Printf.Printf.
+Require Import Printf.Scanf.
+
+Eval compute in (sprintf "%b" 1234).
+(* "10011010010" : string *)
+
+Eval compute in (sscanf "%d %d" (fun n1 n2 s => Some (n1, n2, s)) "12  34  56").
+(* Some (12, 34, "  56") : option (nat * nat * string) *)
+```
+
+## Summary
+
+`sprintf` expects a format string as its first argument, plus one argument
+for every format specifier (`%d`, `%s`, etc.) in that string (there may be
+none), and produces a `string`.
+
+`sscanf` expects a format string as its first argument, a continuation
+as its second argument, and a string to parse as its third argument.
+The continuation takes one argument for every format specifier in the format
+string, plus one more for the remaining string after reaching the end of the
+format string, and produces an `option` result.
+
+```
+sprintf "%d %d" : nat -> nat -> string
+sscanf "%d %d" : (nat -> nat -> string -> option R) -> string -> option R
+(* For any type R *)
+```
+
 ## Format specifiers
 
 The syntax of format specifiers is given by this regular expression:
@@ -55,14 +87,8 @@ type `N` instead of the default `nat`.
 
 The special sequence `%%` encodes a literal `%`.
 
-## Example
-
-```Coq
-Require Import Coq.Strings.String.
-Require Import Printf.Printf.
-
-Eval compute in (sprintf "%b" 1234).
-```
+When used with `scanf`, a whitespace character in a format string will match
+any number of consecutive whitespace characters.
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implementation of `sprintf` for Coq
 The syntax of format specifiers is given by this regular expression:
 
 ```
-%(-|+| |#|0)^* (\d+) (s|b|o|d|x|X|c)
+%(-|+| |#|0)^* (\d+) (s|b|o|d|x|X|c|%)
 ```
 
 which corresponds to this structure:
@@ -37,6 +37,7 @@ which corresponds to this structure:
 | `x`       | hexadecimal lower case |
 | `X`       | hexadecimal upper case |
 | `c`       | character              |
+| `%`       | literal `%`            |
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # cop-printf
 
-Implementation of `sprintf` for Coq
+Implementation of `sprintf` and `sscanf` for Coq
 
 ## Format specifiers
 
 The syntax of format specifiers is given by this regular expression:
 
 ```
-%(-|+| |#|0)^* (\d+) (s|b|o|d|x|X|c|%)
+%(-|+| |#|0)^* (\d+)   (N?)   (s|c|b|o|d|x|X|Zd)
 ```
 
 which corresponds to this structure:
 
 ```
-%[flags]       [width]  specifier
+%[flags]       [width] [type] specifier
 ```
 
 ## Flags
@@ -21,24 +21,39 @@ which corresponds to this structure:
 | Flags | Description                                                                 |
 |-------|-----------------------------------------------------------------------------|
 | `-`   | Left justify                                                                |
-| `+`   | Precede with a plus sign (only applies to `nat`)                            |
+| `+`   | Precede nonnegative numbers with a plus sign (only for `nat`, `N`, `Z`)     |
 | *(space)* | Space if no sign precedes                                               |
 | `#`   | With specifier `o`, `x`, `X`, precede with `0`, `0x`, `0X` respectively for values different than zero |
 | `0`   | Pad with 0's instead of space                                               |
 
+These flags are ignored by `sscanf`.
+
+## Width
+
+The width modifier `(\d+)` gives:
+
+- for `sprintf`, the minimum number of characters to be printed (this enables padding);
+- for `sscanf`, the maximum number of characters to be read for this specifier.
+
+## Type
+
+The type modifier `(N?)` affects the specifiers `b`, `o`, `d`, `x`, `X` to use the
+type `N` instead of the default `nat`.
+
 ## Specifiers
 
-| Specifier | Description            |
-|-----------|------------------------|
-| `s`       | string                 |
-| `b`       | binary                 |
-| `o`       | octal                  |
-| `d`       | decimal                |
-| `x`       | hexadecimal lower case |
-| `X`       | hexadecimal upper case |
-| `c`       | character              |
-| `%`       | literal `%`            |
+| Specifier | Description            | Types      |
+|-----------|------------------------|------------|
+| `s`       | string                 | `string`   |
+| `c`       | character              | `ascii`    |
+| `b`       | binary                 | `nat`, `N` |
+| `o`       | octal                  | `nat`, `N` |
+| `d`       | decimal                | `nat`, `N` |
+| `x`       | hexadecimal lower case | `nat`, `N` |
+| `X`       | hexadecimal upper case | `nat`, `N` |
+| `Zd`      | signed decimal         | `Z`        |
 
+The special sequence `%%` encodes a literal `%`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The continuation takes one argument for every format specifier in the format
 string, plus one more for the remaining string after reaching the end of the
 format string, and produces an `option` result.
 
-```
+```Coq
 sprintf "%d %d" : nat -> nat -> string
 sscanf "%d %d" : (nat -> nat -> string -> option R) -> string -> option R
 (* For any type R *)

--- a/_CoqProject
+++ b/_CoqProject
@@ -4,3 +4,4 @@ theories/Flags.v
 theories/Format.v
 theories/Justify.v
 theories/Printf.v
+theories/Scanf.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,6 @@
 -Q theories Printf
 
 theories/Flags.v
+theories/Format.v
 theories/Justify.v
 theories/Printf.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,6 +1,7 @@
 -Q theories Printf
 
 theories/Flags.v
+theories/Digits.v
 theories/Format.v
 theories/Justify.v
 theories/Printf.v

--- a/test-suite/TestPrintf.v
+++ b/test-suite/TestPrintf.v
@@ -1,28 +1,30 @@
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
+Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 Require Import Printf.Printf.
 
 Local Open Scope string_scope.
 
-Example test_hex_1234: (hex_string 1234) = "4d2"%string.
+Example test_hex_1234: (hex_string 1234) = "4d2".
 Proof.
   unfold hex_string.
   reflexivity.
 Qed.
 
-Example test_4: (hex_string 4) = "4"%string.
+Example test_4: (hex_string 4) = "4".
 Proof.
   unfold hex_string.
   reflexivity.
 Qed.
 
-Example test_1234_hex_upper: (hex_string_upper 1234) = "4D2"%string.
+Example test_1234_hex_upper: (hex_string_upper 1234) = "4D2".
 Proof.
   unfold hex_string.
   reflexivity.
 Qed.
 
-Example test_1234_octal: (octal_string 1234) = "2322"%string.
+Example test_1234_octal: (octal_string 1234) = "2322".
 Proof.
   unfold hex_string.
   reflexivity.
@@ -68,6 +70,36 @@ Proof.
   reflexivity.
 Qed.
 
+Goal sprintf "%Nd" 1234%N = "1234".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sprintf "%NX" 1234%N = "4D2".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sprintf "%Nx" 1234%N = "4d2".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sprintf "%Zd" 1234%Z = "1234".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sprintf "%Zd" (-1234)%Z = "-1234".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sprintf "%+Zd" 1234%Z = "+1234".
+Proof.
+  reflexivity.
+Qed.
+
 Goal (sprintf "%o, %x, %X, %b, ..." 1234 1234 1234 1234) = "2322, 4d2, 4D2, 10011010010, ...".
 Proof.
   reflexivity.
@@ -83,38 +115,37 @@ Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "%-4X" 1234 = "4D2 "%string.
+Goal sprintf "%-4X" 1234 = "4D2 ".
 Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "%-05X" 1234 = "4D200"%string.
+Goal sprintf "%-05X" 1234 = "4D200".
 Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "% d" 1234 = " 1234"%string.
+Goal sprintf "% d" 1234 = " 1234".
 Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "%+d" 1234 = "+1234"%string.
+Goal sprintf "%+d" 1234 = "+1234".
 Proof.
   reflexivity.
 Qed.
 
-
-Goal sprintf "%-#05X" 1234 = "0X4D2"%string.
+Goal sprintf "%-#05X" 1234 = "0X4D2".
 Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "%-#05X" 0 = "00000"%string.
+Goal sprintf "%-#05X" 0 = "00000".
 Proof.
   reflexivity.
 Qed.
 
-Goal sprintf "%-#05x" 1234 = "0x4d2"%string.
+Goal sprintf "%-#05x" 1234 = "0x4d2".
 Proof.
   reflexivity.
 Qed.

--- a/test-suite/TestScanf.v
+++ b/test-suite/TestScanf.v
@@ -1,0 +1,81 @@
+Require Import Coq.Strings.Ascii.
+Require Import Coq.Strings.String.
+Require Import Printf.Scanf.
+
+Local Open Scope string_scope.
+
+Definition ret {A B : Type} (a : A) (_ : B) : option A := Some a.
+
+Goal sscanf "Hello, %s" ret "Hello, world!" = Some "world!".
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%d, %d, %d, ..." (fun a b c _ => Some (a, b, c)) "1, 2, 3, ..."
+  = Some (1, 2, 3).
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%d%%" ret "100%" = Some 100.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%c" ret "x" = Some "x"%char.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%o" ret "2322" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%x" ret "4d2" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%X" ret "4D2" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%b" ret "10011010010" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%o, %x, %X, %b, ..."
+            (fun a b c d _ => Some (a, b, c, d))
+            "2322, 4d2, 4D2, 10011010010, ..."
+  = Some (1234, 1234, 1234, 1234).
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf " %3X" (fun n s => Some (n, s)) " 4D2ABC" = Some (1234, "ABC").
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%5X" (fun n s => Some (n, s)) "004D21" = Some (1234, "1").
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%d" ret "+1234" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%X" ret "0X4D2" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%x" ret "0x4d2" = Some 1234.
+Proof.
+  reflexivity.
+Qed.

--- a/test-suite/TestScanf.v
+++ b/test-suite/TestScanf.v
@@ -1,5 +1,7 @@
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
+Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 Require Import Printf.Scanf.
 
 Local Open Scope string_scope.
@@ -47,6 +49,36 @@ Proof.
   reflexivity.
 Qed.
 
+Goal sscanf "%Nd" ret "1234" = Some 1234%N.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%NX" ret "4D2" = Some 1234%N.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%Nx" ret "4d2" = Some 1234%N.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%Zd" ret "1234" = Some 1234%Z.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%Zd" ret "-1234" = Some (-1234)%Z.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%Zd" ret "+1234" = Some 1234%Z.
+Proof.
+  reflexivity.
+Qed.
+
 Goal sscanf "%o, %x, %X, %b, ..."
             (fun a b c d _ => Some (a, b, c, d))
             "2322, 4d2, 4D2, 10011010010, ..."
@@ -76,6 +108,11 @@ Proof.
 Qed.
 
 Goal sscanf "%x" ret "0x4d2" = Some 1234.
+Proof.
+  reflexivity.
+Qed.
+
+Goal sscanf "%Zd" ret "-32" = Some (-32)%Z.
 Proof.
   reflexivity.
 Qed.

--- a/test-suite/_CoqProject
+++ b/test-suite/_CoqProject
@@ -2,3 +2,5 @@
 -R . Printf
 
 demo.v
+TestPrintf.v
+TestScanf.v

--- a/theories/Digits.v
+++ b/theories/Digits.v
@@ -97,8 +97,7 @@ Local Fixpoint string_of_digits_
     (digit : N -> ascii)
     (s : string)
     (n : digits)
-  : string
-  :=
+  : string :=
   match n with
   | Zero => s
   | Digit n d => string_of_digits_ digit (String (digit d) s) n

--- a/theories/Digits.v
+++ b/theories/Digits.v
@@ -1,0 +1,112 @@
+(** Numbers represented as lists of digits. *)
+
+Require Import Coq.NArith.NArith.
+Require Import Coq.Strings.String.
+Require Import Coq.Strings.Ascii.
+
+Local Open Scope N.
+
+Inductive digits : Set :=
+| Zero
+| Digit : digits -> N -> digits
+.
+
+Arguments digits : clear implicits.
+
+Section Digits.
+
+Context (base : N).
+
+(** Add two digits and a carry *)
+Definition adder (d d0 c : N) : N * N :=
+  let s := c + d + d0 in
+  if s <? base then (0, s) else (1, s - base).
+
+(* [2 * n + d0] *)
+Fixpoint double_plus (c : N) (n : digits) :=
+  match n with
+  | Zero =>
+    if c =? 0 then Zero else Digit Zero c
+  | Digit n d =>
+    let (c, d) := adder d d c in
+    Digit (double_plus c n) d
+  end.
+
+Fixpoint digits_of_pos (p : positive) :=
+  match p with
+  | xH => Digit Zero 1
+  | xI p => double_plus 1 (digits_of_pos p)
+  | xO p => double_plus 0 (digits_of_pos p)
+  end.
+
+Definition digits_of_N (n : N) :=
+  match n with
+  | N0 => Digit Zero 0
+  | Npos p => digits_of_pos p
+  end.
+
+End Digits.
+
+Definition binary_ascii (n : N) : ascii :=
+  match n with
+  | 0 =>  "0"%char
+  | _ =>  "1"%char
+  end.
+
+Definition octal_ascii (n : N) : ascii :=
+  match n with
+  | 0 =>  "0"%char
+  | 1 =>  "1"%char
+  | 2 =>  "2"%char
+  | 3 =>  "3"%char
+  | 4 =>  "4"%char
+  | 5 =>  "5"%char
+  | 6 =>  "6"%char
+  | _ =>  "7"%char
+  end.
+
+Definition decimal_ascii (n : N) : ascii :=
+  match n with
+  | 8 =>  "8"%char
+  | 9 =>  "9"%char
+  | _ => octal_ascii n
+  end.
+
+Definition hex_ascii (n : N) : ascii :=
+  match n with
+  | 10 => "a"%char
+  | 11 => "b"%char
+  | 12 => "c"%char
+  | 13 => "d"%char
+  | 14 => "e"%char
+  | 15 => "f"%char
+  | _  => decimal_ascii n
+  end.
+
+Definition hex_ascii_upper (n : N) : ascii :=
+  match n with
+  | 10 => "A"%char
+  | 11 => "B"%char
+  | 12 => "C"%char
+  | 13 => "D"%char
+  | 14 => "E"%char
+  | 15 => "F"%char
+  | _  => decimal_ascii n
+  end.
+
+Local Fixpoint string_of_digits_
+    (digit : N -> ascii)
+    (s : string)
+    (n : digits)
+  : string
+  :=
+  match n with
+  | Zero => s
+  | Digit n d => string_of_digits_ digit (String (digit d) s) n
+  end.
+
+Definition string_of_digits (digit : N -> ascii) : digits -> string :=
+  string_of_digits_ digit "".
+
+Definition string_of_N (base : N) (digit : N -> ascii) (n : N) : string :=
+  string_of_digits digit (digits_of_N base n).

--- a/theories/Digits.v
+++ b/theories/Digits.v
@@ -55,14 +55,13 @@ Definition binary_ascii (n : N) : ascii :=
 
 Definition octal_ascii (n : N) : ascii :=
   match n with
-  | 0 =>  "0"%char
-  | 1 =>  "1"%char
   | 2 =>  "2"%char
   | 3 =>  "3"%char
   | 4 =>  "4"%char
   | 5 =>  "5"%char
   | 6 =>  "6"%char
-  | _ =>  "7"%char
+  | 7 =>  "7"%char
+  | _ => binary_ascii n
   end.
 
 Definition decimal_ascii (n : N) : ascii :=

--- a/theories/Format.v
+++ b/theories/Format.v
@@ -26,7 +26,7 @@ Definition on_success {E R : Type} {er : E + R} {k : R -> Type} (f : forall r, k
 
 (** ** String utilities *)
 
-Infix "::" := String : string_scope.
+Local Infix "::" := String : string_scope.
 
 Definition ascii_digit (c : ascii) : nat :=
   match c with

--- a/theories/Format.v
+++ b/theories/Format.v
@@ -1,0 +1,146 @@
+Require Import Coq.Strings.Ascii.
+Require Import Coq.Strings.String.
+Require Import Printf.Flags.
+
+(** ** Error handling in dependent types *)
+
+(** This tagged unit type indicates an error in the computation of a type. *)
+Variant tyerror {A : Type} (a : A) : Set := Invalid.
+
+(** Construct a dependent type from a computation which may fail. *)
+Definition for_good {E R : Type} (er : E + R) (k : R -> Type) : Type :=
+  match er with
+  | inl e => tyerror e
+  | inr r => k r
+  end.
+
+(** Apply a dependent function to the result of a computation when it is successful. *)
+Definition on_success {E R : Type} {er : E + R} {k : R -> Type} (f : forall r, k r)
+  : for_good er k
+  :=
+  match er with
+  | inl e => Invalid e
+  | inr r => f r
+  end.
+
+(** ** String utilities *)
+
+Infix "::" := String : string_scope.
+
+Definition ascii_digit (c : ascii) : nat :=
+  match c with
+  | "0" => 0
+  | "1" => 1
+  | "2" => 2
+  | "3" => 3
+  | "4" => 4
+  | "5" => 5
+  | "6" => 6
+  | "7" => 7
+  | "8" => 8
+  | "9" => 9
+  | "a" | "A" => 10
+  | "b" | "B" => 11
+  | "c" | "C" => 12
+  | "d" | "D" => 13
+  | "e" | "E" => 14
+  | "f" | "F" => 15
+  | _ => 0
+  end%char.
+
+(** ** Format strings *)
+
+Module Format.
+
+Variant number_type : Type :=
+| Binary
+| Octal
+| Decimal
+| HexLower
+| HexUpper
+.
+
+Variant type : Type :=
+| Number : number_type -> type
+| String
+| Char
+.
+
+(** Well-formed format strings *)
+Inductive t : Type :=
+| Empty
+| Literal : ascii -> t -> t
+| Hole : type -> options -> t -> t
+.
+
+(** Parser state machine. *)
+Local Variant state : Type :=
+| Ini                                   (* Initial state *)
+| Spec (inWidth : bool) (o : options)  (* Parsing specifier *)
+  (* [inWidth]: [true] if we're in the middle of the width segment *)
+  (* [o]: currently accumulated options *)
+.
+
+(** Parser error: dump the remaining string, that serves to locate the error. *)
+Variant error : Type :=
+| ErrorAt (i : state) (s : string)
+.
+
+(** Parse string [s] in state [i] into a format which is passed to the final
+  continuation [k], or return an error. *)
+Local Fixpoint parse_ {r : Type} (i : state) (k : t -> r) (s0 : string)
+  : error + r
+  :=
+  match i, s0 with
+    (* The initial state looks for ["%"], indicating a specifier,
+       and keeps the rest as literal. *)
+  | Ini, "" => inr (k Empty)
+  | Ini, "%" :: "%" :: s => parse_ Ini (fun fmt => k (Literal "%" fmt)) s
+  | Ini, "%" :: s => parse_ (Spec false default_options) k s
+  | Ini, c :: s => parse_ Ini (fun fmt => k (Literal c fmt)) s
+
+  | Spec _ _, "" => inl (ErrorAt i s0)
+  | Spec w o, a :: s =>
+    (* When parsing a specifier, the next character is either:
+       - a specifier character, then update the format and go back to the initial state;
+       - or a flag (or width) character, then update the options accordingly. *)
+    let specifier (t : type) := parse_ Ini (fun fmt => k (Hole t o fmt)) s in
+    let flag (inWidth : bool) (o : options) := parse_ (Spec inWidth o) k s in
+    match a, w with
+    | "s", _ => specifier String
+    | "c", _ => specifier Char
+    | "b", _ => specifier (Number Binary)
+    | "o", _ => specifier (Number Octal)
+    | "d", _ => specifier (Number Decimal)
+    | "x", _ => specifier (Number HexLower)
+    | "X", _ => specifier (Number HexUpper)
+    | "-", false => flag false (update_option_justify o LeftJustify)
+    | "+", false => flag false (update_option_sign o true)
+    | " ", false => flag false (update_option_space o true)
+    | "#", false => flag false (update_option_prefix o true)
+    | "0", false => flag false (update_option_zero_pad o true)
+    | ("1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"), _
+    | "0", true  => flag true (update_option_width o (ascii_digit a))
+    | _, _ => inl (ErrorAt i s0)
+    end%char
+  end%string.
+
+Definition parse : string -> error + t := parse_ Ini id.
+
+Definition hole_type (ty : type) : Type :=
+  match ty with
+  | Number _ => nat
+  | String => string
+  | Char => ascii
+  end.
+
+(** Type of continuations associated with format string [fmt],
+    with result type [r]. *)
+Fixpoint holes (r : Type) (fmt : t) : Type :=
+  match fmt with
+  | Empty => r
+  | Hole ty _ fmt => hole_type ty -> holes r fmt
+  | Literal _ fmt => holes r fmt
+  end.
+
+End Format.

--- a/theories/Format.v
+++ b/theories/Format.v
@@ -18,8 +18,7 @@ Definition for_good {E R : Type} (er : E + R) (k : R -> Type) : Type :=
 
 (** Apply a dependent function to the result of a computation when it is successful. *)
 Definition on_success {E R : Type} {er : E + R} {k : R -> Type} (f : forall r, k r)
-  : for_good er k
-  :=
+  : for_good er k :=
   match er with
   | inl e => Invalid e
   | inr r => f r
@@ -106,8 +105,7 @@ Variant error : Type :=
 (** Parse string [s] in state [i] into a format which is passed to the final
   continuation [k], or return an error. *)
 Local Fixpoint parse_ {r : Type} (i : state) (k : t -> r) (s0 : string)
-  : error + r
-  :=
+  : error + r :=
   match i, s0 with
     (* The initial state looks for ["%"], indicating a specifier,
        and keeps the rest as literal. *)

--- a/theories/Printf.v
+++ b/theories/Printf.v
@@ -93,8 +93,7 @@ Definition format_X : options -> N -> string -> string :=
   format_nat hex_string_upper (Some "0X"%string).
 
 Definition format_number (b : Format.number_enctype) (t : Format.number_dectype)
-  : options -> Format.dectype_type t -> string -> string
-  :=
+  : options -> Format.dectype_type t -> string -> string :=
   fun o =>
   let format_ :=
     match b with
@@ -122,8 +121,7 @@ Definition format_Z : options -> Z -> string -> string :=
   end.
 
 Definition format (ty : Format.type)
-  : options -> Format.hole_type ty -> string -> string
-  :=
+  : options -> Format.hole_type ty -> string -> string :=
   match ty return _ -> Format.hole_type ty -> _ with
   | Format.Number b t => format_number b t
   | Format.SDecimal => format_Z
@@ -132,8 +130,7 @@ Definition format (ty : Format.type)
   end.
 
 Local Fixpoint sprintf' (acc : string -> string) (fmt : Format.t)
-  : Format.holes string fmt
-  :=
+  : Format.holes string fmt :=
   match fmt return Format.holes string fmt with
   | Format.Empty => acc ""%string
   | Format.Literal c fmt => sprintf' (fun s => acc (c :: s)%string) fmt

--- a/theories/Printf.v
+++ b/theories/Printf.v
@@ -10,6 +10,8 @@ Require Import Printf.Digits.
 
 Set Primitive Projections.
 
+Local Infix "::" := String : string_scope.
+
 (* Justify *)
 Definition justify_string (o : options) (s : string) : string :=
   let a := if option_zero_pad o then "0"%char else " "%char in

--- a/theories/Printf.v
+++ b/theories/Printf.v
@@ -1,13 +1,12 @@
 Require Import Coq.Strings.Ascii.
 Require Import Coq.Strings.String.
-Require Import Coq.Init.Nat.
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.Program.Wf.
-Require Import Coq.Program.Basics.
+Require Import Coq.NArith.NArith.
+Require Import Coq.ZArith.ZArith.
 
 Require Import Printf.Justify.
 Require Import Printf.Flags.
 Require Import Printf.Format.
+Require Import Printf.Digits.
 
 Set Primitive Projections.
 
@@ -31,116 +30,32 @@ Definition sign_string (o : options) (s : string) : string :=
   | (_,_) => s
   end.
 
+Local Open Scope N.
+
 (* prefix *)
-Definition prefix_string (o : options) (prefix : string) (n : nat) (s : string) : string :=
+Definition prefix_string (o : options) (prefix : string) (n : N) (s : string) : string :=
   match n with
   | 0 => s
-  | S _ => if option_prefix o then
+  | _ => if option_prefix o then
              append prefix s
            else
              s
   end.
 
-Definition binary_ascii (n : nat) : ascii :=
-  match n with
-  | 0 =>  "0"%char
-  | _ =>  "1"%char
-  end.
+Definition binary_string (n : N) :=
+  string_of_N 2 binary_ascii n.
 
-Definition octal_ascii (n : nat) : ascii :=
-  match n with
-  | 0 =>  "0"%char
-  | 1 =>  "1"%char
-  | 2 =>  "2"%char
-  | 3 =>  "3"%char
-  | 4 =>  "4"%char
-  | 5 =>  "5"%char
-  | 6 =>  "6"%char
-  | _ =>  "7"%char
-  end.
+Definition hex_string (n : N) :=
+  string_of_N 16 hex_ascii n.
 
-Definition decimal_ascii (n : nat) : ascii :=
-  match n with
-  | 8 =>  "8"%char
-  | 9 =>  "9"%char
-  | _ => octal_ascii n
-  end.
+Definition hex_string_upper (n : N) :=
+  string_of_N 16 hex_ascii_upper n.
 
-Definition hex_ascii (n : nat) : ascii :=
-  match n with
-  | 10 => "a"%char
-  | 11 => "b"%char
-  | 12 => "c"%char
-  | 13 => "d"%char
-  | 14 => "e"%char
-  | 15 => "f"%char
-  | _  => decimal_ascii n
-  end.
+Definition octal_string (n : N) :=
+  string_of_N 8 octal_ascii n.
 
-Definition hex_ascii_upper (n : nat) : ascii :=
-  match n with
-  | 10 => "A"%char
-  | 11 => "B"%char
-  | 12 => "C"%char
-  | 13 => "D"%char
-  | 14 => "E"%char
-  | 15 => "F"%char
-  | _  => decimal_ascii n
-  end.
-
-Program Fixpoint nat_to_string
-         (base : nat | 1 < base)
-         (to_digit : nat -> ascii)
-         (acc: string)
-         (n:nat) {measure n}
-         : string :=
-  let acc' := (String (to_digit (n mod base)) acc) in
-  if Compare_dec.le_gt_dec n (base - 1) then
-    acc'
-  else
-    nat_to_string base to_digit acc' (n / base)
-.
-Next Obligation.
-  eapply Nat.div_lt.
-  assert(base - 1 > 0).
-  apply Minus.lt_O_minus_lt.
-  rewrite <- Minus.minus_n_O.
-  apply Lt.lt_S_n.
-  rewrite <- Minus.pred_of_minus.
-  assert (Ha' := Nat.lt_succ_pred 1 base).
-  rewrite Ha'; assumption.
-  assert (Hb' := Gt.gt_trans n (base - 1) 0).
-  apply Hb'; assumption.
-  assumption.
-Qed.
-
-Program Definition binary_string (n : nat) :=
-  nat_to_string 2 binary_ascii EmptyString n.
-
-
-Program Definition hex_string (n : nat) :=
-  nat_to_string 16 hex_ascii EmptyString n.
-Next Obligation.
-  apply Lt.lt_n_S; apply Gt.gt_Sn_O.
-Defined.
-
-Program Definition hex_string_upper (n : nat) :=
-  nat_to_string 16 hex_ascii_upper EmptyString n.
-Next Obligation.
-  apply Lt.lt_n_S; apply Gt.gt_Sn_O.
-Defined.
-
-Program Definition octal_string (n : nat) :=
-  nat_to_string 8 octal_ascii EmptyString n.
-Next Obligation.
-  apply Lt.lt_n_S; apply Gt.gt_Sn_O.
-Defined.
-
-Program Definition decimal_string (n : nat) :=
-  nat_to_string 10 decimal_ascii EmptyString n.
-Next Obligation.
-  apply Lt.lt_n_S; apply Gt.gt_Sn_O.
-Defined.
+Definition decimal_string (n : N) :=
+  string_of_N 10 decimal_ascii n.
 
 (* helper methods to format *)
 Definition format_s
@@ -151,10 +66,10 @@ Definition format_s
   (String.append text x).
 
 Definition format_nat
-           (f : nat -> string)
+           (f : N -> string)
            (prefix : option string)
            (o : options)
-           (n : nat) : string -> string :=
+           (n : N) : string -> string :=
   let text := f n in
   let text := match prefix with
               | Some prefix' => prefix_string o prefix' n text
@@ -162,30 +77,56 @@ Definition format_nat
               end in
   format_s o text.
 
-Definition format_b : options -> nat -> string -> string :=
+Definition format_b : options -> N -> string -> string :=
   format_nat binary_string None.
 
-Definition format_o : options -> nat -> string -> string :=
+Definition format_o : options -> N -> string -> string :=
   format_nat octal_string (Some "0"%string).
 
-Definition format_d (o : options) : nat -> string -> string :=
-  format_nat (fun (n : nat) => sign_string o (decimal_string n)) None o.
+Definition format_d (o : options) : N -> string -> string :=
+  format_nat (fun (n : N) => sign_string o (decimal_string n)) None o.
 
-Definition format_x : options -> nat -> string -> string :=
+Definition format_x : options -> N -> string -> string :=
   format_nat hex_string (Some "0x"%string).
 
-Definition format_X : options -> nat -> string -> string :=
+Definition format_X : options -> N -> string -> string :=
   format_nat hex_string_upper (Some "0X"%string).
+
+Definition format_number (b : Format.number_enctype) (t : Format.number_dectype)
+  : options -> Format.dectype_type t -> string -> string
+  :=
+  fun o =>
+  let format_ :=
+    match b with
+    | Format.Binary => format_b
+    | Format.Octal => format_o
+    | Format.Decimal => format_d
+    | Format.HexLower => format_x
+    | Format.HexUpper => format_X
+    end o in
+  match t as t0 return Format.dectype_type t0 -> _ with
+  | Format.T_Nat => fun n => format_ (N.of_nat n)
+  | Format.T_N => fun n => format_ n
+  end.
+
+Definition format_Z : options -> Z -> string -> string :=
+  fun o n =>
+  let format_ := format_nat decimal_string None o in
+  match n with
+  | Z0 => format_ 0
+  | Zpos p => fun s =>
+    if option_sign o
+    then ("+" :: format_ (Npos p) s)%string
+    else         format_ (Npos p) s
+  | Zneg p => fun s => ("-" :: format_ (Npos p) s)%string
+  end.
 
 Definition format (ty : Format.type)
   : options -> Format.hole_type ty -> string -> string
   :=
   match ty return _ -> Format.hole_type ty -> _ with
-  | Format.Number Format.Binary => format_b
-  | Format.Number Format.Octal => format_o
-  | Format.Number Format.Decimal => format_d
-  | Format.Number Format.HexLower => format_x
-  | Format.Number Format.HexUpper => format_X
+  | Format.Number b t => format_number b t
+  | Format.SDecimal => format_Z
   | Format.String => format_s
   | Format.Char => fun o c => format_s o (c :: "")
   end.

--- a/theories/Scanf.v
+++ b/theories/Scanf.v
@@ -8,6 +8,8 @@ Require Import Printf.Format.
 
 Set Primitive Projections.
 
+Local Infix "::" := String : string_scope.
+
 Definition fmt_parser (R : Type) (fmt : Format.t) : Type :=
   Format.holes (string -> option R) fmt -> string -> option R.
 

--- a/theories/Scanf.v
+++ b/theories/Scanf.v
@@ -113,8 +113,7 @@ Local Definition parse_N_ (base : N) (digit : ascii -> option N)
     (continue : option N -> string -> option R)
     (x : option N)
     (s0 : string)
-  : option R
-  :=
+  : option R :=
   match s0 with
   | "" =>
     match x with
@@ -144,8 +143,8 @@ Definition parse_N (base : N) (digit : ascii -> option N) : parser R N := fun k 
 
 (** Parse a number of at most [w] characters. *)
 Definition parse_N' (w : nat) (base : N) (digit : ascii -> option N)
-  : parser R N
-  := fun k =>
+  : parser R N :=
+  fun k =>
   let fix _parse_N (w : nat) (x : option N) (s0 : string) :=
     match w with
     | O =>
@@ -164,8 +163,8 @@ Definition parse_char : parser R ascii := fun k s =>
   end.
 
 Definition parse_this_char (c : ascii)
-  : parser R unit
-  := fun k s =>
+  : parser R unit :=
+  fun k s =>
   match s with
   | "" => None
   | c' :: s =>
@@ -193,8 +192,7 @@ Local Definition parse_string_
     (continue : parser R string)
     (k : string -> string -> option R)
     (s0 : string)
-  : option R
-  :=
+  : option R :=
   match s0 with
   | "" => k "" s0
   | c :: s =>
@@ -220,8 +218,7 @@ Definition parse_number
     (b : Format.number_enctype)
     (t : Format.number_dectype)
     (o : options)
-  : parser R (Format.dectype_type t)
-  :=
+  : parser R (Format.dectype_type t) :=
   fun k s =>
   let parse :=
     match option_width o with
@@ -243,8 +240,7 @@ Definition parse_number
 
 Definition parse_signed
     (o : options)
-  : parser R Z
-  :=
+  : parser R Z :=
   fun k s =>
   let parse :=
     match option_width o with
@@ -259,8 +255,7 @@ Definition parse_signed
   end.
 
 Definition parse_hole (ty : Format.type) (o : options)
-  : parser R (Format.hole_type ty)
-  :=
+  : parser R (Format.hole_type ty) :=
   match ty with
   | Format.String =>
     match option_width o with
@@ -273,8 +268,7 @@ Definition parse_hole (ty : Format.type) (o : options)
   end.
 
 Local Fixpoint parse_fmt (fmt : Format.t)
-  : fmt_parser R fmt
-  :=
+  : fmt_parser R fmt :=
   match fmt with
   | Format.Empty => fun k => k
   | Format.Literal " " fmt => fun k => parse_whitespace (fun _ => parse_fmt fmt k)

--- a/theories/Scanf.v
+++ b/theories/Scanf.v
@@ -1,0 +1,257 @@
+Require Import Coq.Strings.Ascii.
+Require Import Coq.Strings.String.
+Require Import Coq.NArith.NArith.
+Require Import Printf.Justify.
+Require Import Printf.Flags.
+Require Import Printf.Format.
+
+Set Primitive Projections.
+
+Definition fmt_parser (R : Type) (fmt : Format.t) : Type :=
+  Format.holes (string -> option R) fmt -> string -> option R.
+
+Definition parser (R A : Type) : Type :=
+  (A -> string -> option R) -> string -> option R.
+
+Definition base (ty : Format.number_type) : N :=
+  match ty with
+  | Format.Binary => 2
+  | Format.Octal => 8
+  | Format.Decimal => 10
+  | Format.HexLower | Format.HexUpper => 16
+  end.
+
+Module Read.
+
+Local Open Scope char.
+Local Open Scope N.
+
+Definition binary (c : ascii) : option N :=
+  match c with
+  | "0" => Some 0
+  | "1" => Some 1
+  | _ => None
+  end.
+
+Definition octal (c : ascii) : option N :=
+  match c with
+  | "0" => Some 0
+  | "1" => Some 1
+  | "2" => Some 2
+  | "3" => Some 3
+  | "4" => Some 4
+  | "5" => Some 5
+  | "6" => Some 6
+  | "7" => Some 7
+  | _ => None
+  end.
+
+Definition decimal (c : ascii) : option N :=
+  match c with
+  | "0" => Some 0
+  | "1" => Some 1
+  | "2" => Some 2
+  | "3" => Some 3
+  | "4" => Some 4
+  | "5" => Some 5
+  | "6" => Some 6
+  | "7" => Some 7
+  | "8" => Some 8
+  | "9" => Some 9
+  | _ => None
+  end.
+
+Definition hex (c : ascii) : option N :=
+  match c with
+  | "0" => Some 0
+  | "1" => Some 1
+  | "2" => Some 2
+  | "3" => Some 3
+  | "4" => Some 4
+  | "5" => Some 5
+  | "6" => Some 6
+  | "7" => Some 7
+  | "8" => Some 8
+  | "9" => Some 9
+  | "a" | "A" => Some 10
+  | "b" | "B" => Some 11
+  | "c" | "C" => Some 12
+  | "d" | "D" => Some 13
+  | "e" | "E" => Some 14
+  | "f" | "F" => Some 15
+  | _ => None
+  end.
+
+Definition digit (ty : Format.number_type) : ascii -> option N :=
+  match ty with
+  | Format.Binary => binary
+  | Format.Octal => octal
+  | Format.Decimal => decimal
+  | Format.HexLower | Format.HexUpper => hex
+  end.
+
+End Read.
+
+Section Parser.
+
+Local Open Scope string.
+
+Context {R : Type}.
+
+(** The body of the recursive definitions of [parse_N] and [parse_N'].
+  If the next character is a digit, accumulate it into [x] and call [continue]
+  on the updated state and the remaining string.
+  Else if the state [x] is empty, fail.
+  Otherwise, terminate by calling [k].
+
+  To ensure the subsequent definitions are guarded, [continue] is applied to a
+  subterm of [s0].
+  *)
+Local Definition parse_N_ (base : N) (digit : ascii -> option N)
+    (k : N -> string -> option R)
+    (continue : option N -> string -> option R)
+    (x : option N)
+    (s0 : string)
+  : option R
+  :=
+  match s0 with
+  | "" =>
+    match x with
+    | None => None
+    | Some n => k n ""
+    end
+  | c :: s =>
+    match digit c with
+    | None =>
+      match x with
+      | None => None
+      | Some n => k n s0
+      end
+    | Some d =>
+      match x with
+      | None => continue (Some d) s
+      | Some n => continue (Some (n * base + d)%N) s
+      end
+    end
+  end.
+
+(** Parse a number given a translation from characters to numbers. *)
+Definition parse_N (base : N) (digit : ascii -> option N) : parser R N := fun k =>
+  let fix _parse_N (x : option N) (s0 : string) :=
+    parse_N_ base digit k _parse_N x s0
+  in _parse_N None.
+
+(** Parse a number of at most [w] characters. *)
+Definition parse_N' (w : nat) (base : N) (digit : ascii -> option N)
+  : parser R N
+  := fun k =>
+  let fix _parse_N (w : nat) (x : option N) (s0 : string) :=
+    match w with
+    | O =>
+      match x with
+      | None => None
+      | Some n => k n s0
+      end
+    | S w => parse_N_ base digit k (_parse_N w) x s0
+    end
+  in _parse_N w None.
+
+Definition parse_char : parser R ascii := fun k s =>
+  match s with
+  | "" => None
+  | c :: s => k c s
+  end.
+
+Definition parse_this_char (c : ascii)
+  : parser R unit
+  := fun k s =>
+  match s with
+  | "" => None
+  | c' :: s =>
+    if Ascii.eqb c c'
+    then k tt s
+    else None
+  end.
+
+Definition is_whitespace (c : ascii) : bool :=
+  match c with
+  | " " | "009" | "010" | "011" | "012" | "013" => true
+  | _ => false
+  end%char.
+
+Definition parse_whitespace : parser R unit := fun k =>
+  fix consume s0 :=
+    match s0 with
+    | c :: s =>
+      if is_whitespace c then consume s else k tt s0
+    | _ => k tt s0
+    end.
+
+(** Body of the recursive definition of [parse_string] and [parse_string']. *)
+Local Definition parse_string_
+    (continue : parser R string)
+    (k : string -> string -> option R)
+    (s0 : string)
+  : option R
+  :=
+  match s0 with
+  | "" => k "" s0
+  | c :: s =>
+    if is_whitespace c
+    then k "" s0
+    else continue (fun z => k (c :: z)) s
+  end.
+
+(** Read up to the next whitespace character *)
+Definition parse_string : parser R string :=
+  fix _parse_string k (s : string) :=
+    parse_string_ _parse_string k s.
+
+(** Read at most [w] characters up to the next whitespace character. *)
+Definition parse_string' : nat -> parser R string :=
+  fix _parse_string w k (s : string) :=
+    match w with
+    | O => k "" s
+    | S w => parse_string_ (_parse_string w) k s
+    end.
+
+Definition parse_hole (ty : Format.type) (o : options)
+  : parser R (Format.hole_type ty)
+  :=
+  match ty with
+  | Format.String =>
+    match option_width o with
+    | None => parse_string
+    | Some w => parse_string' w
+    end
+  | Format.Char => parse_char
+  | Format.Number b
+    => fun k s =>
+      let parse :=
+        match option_width o with
+        | None => parse_N
+        | Some w => parse_N' w
+        end
+      in
+      match b, s with
+      | (Format.HexLower | Format.HexUpper), "0" :: ("x" | "X") :: s
+      | _, "+" :: s
+      | _, s
+        => parse (base b) (Read.digit b) (fun n => k (N.to_nat n)) s
+      end
+  end.
+
+Local Fixpoint parse_fmt (fmt : Format.t)
+  : fmt_parser R fmt
+  :=
+  match fmt with
+  | Format.Empty => fun k => k
+  | Format.Literal " " fmt => fun k => parse_whitespace (fun _ => parse_fmt fmt k)
+  | Format.Literal c fmt => fun k => parse_this_char c (fun _ => parse_fmt fmt k)
+  | Format.Hole ty o fmt => fun k => parse_hole ty o (fun x => parse_fmt fmt (k x))
+  end.
+
+Definition sscanf (s : string) : for_good (Format.parse s) (fmt_parser R) :=
+  on_success parse_fmt.
+
+End Parser.


### PR DESCRIPTION
The logic for parsing the format string was annoying to duplicate, so instead I first parse format strings into a common inductive representation (`Printf.Format.Format.t`, or `Format.t` for short).

