### PR TITLE
Remove Local modifier from Variant (deprecated in Coq 8.10)

### DIFF
--- a/theories/Format.v
+++ b/theories/Format.v
@@ -83,14 +83,14 @@ Inductive t : Type :=
 | Hole : type -> options -> t -> t
 .
 
-Local Variant spec_state : Type :=
+Variant spec_state : Type :=
 | Flags
 | Width
 | TySpec (t : number_dectype)
 .
 
 (** Parser state machine. *)
-Local Variant state : Type :=
+Variant state : Type :=
 | Ini                                  (* Initial state *)
 | Spec (j : spec_state) (o : options)  (* Parsing specifier *)
   (* [j]: inner specifier parsing state *)


### PR DESCRIPTION
It would be nice to make a release with the latest features!